### PR TITLE
Add support for Open-Meteo commercial endpoints via OPENMETEO_API_KEY

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,8 @@ BugReports: https://github.com/tpisel/openmeteo/issues
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
+Depends:
+    R (>= 4.1.0)
 Imports:
     httr,
     tibble,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# openmeteo 0.2.5.9000
+
+* Added support for querying commercial customer endpoints with a paid Open-Meteo subscription by setting the `OPENMETEO_API_KEY` environment variable.
+* Updated package requirements to depend on R \>= 4.1.0.
+* Updated `README.md` to include information about how to access the commercial endpoints.
+
 # openmeteo 0.2.5
 
 * New `ensemble_models()` function for the Open-Meteo Ensemble Models API (#10, thanks @jacobmmears)

--- a/R/air_quality.R
+++ b/R/air_quality.R
@@ -80,7 +80,7 @@ air_quality <- function(
     stop("start and end dates must be in ISO-1806 format")
   }
 
-  base_url <- "https://air-quality-api.open-meteo.com/v1/air-quality"
+  base_url <- .lookup_open_meteo_url(fxn_name = "air_quality")
 
   .query_openmeteo(
     location,

--- a/R/climate_forecast.R
+++ b/R/climate_forecast.R
@@ -96,7 +96,7 @@ climate_forecast <- function(
   if (!is.logical(downscaling)) {
     stop("parameter downscaling must be TRUE or FALSE")
   }
-  base_url <- "https://climate-api.open-meteo.com/v1/climate"
+  base_url <- .lookup_open_meteo_url(fxn_name = "climate_forecast")
 
   .query_openmeteo(
     location,

--- a/R/ensemble_models.R
+++ b/R/ensemble_models.R
@@ -88,7 +88,7 @@ ensemble_models <- function(
     stop("start and end dates must be in ISO-1806 format")
   }
 
-  base_url <- "https://ensemble-api.open-meteo.com/v1/ensemble"
+  base_url <- .lookup_open_meteo_url(fxn_name = "ensemble_models")
 
   .query_openmeteo(
     location,

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -43,7 +43,7 @@ geocode <- function(location_name,
   if (!is.character(location_name)) stop("location_name must be string")
   if (!is.numeric(n_results)) stop("n_results must be integer/numeric")
 
-  base_url <- httr::parse_url("https://geocoding-api.open-meteo.com/v1/search")
+  base_url <- httr::parse_url(base_url <- .lookup_open_meteo_url(fxn_name = "geocode"))
 
   queries <- list(
     name = location_name,

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -51,6 +51,12 @@ geocode <- function(location_name,
     language = language
   )
 
+  api_key <- Sys.getenv("OPENMETEO_API_KEY", unset = NA_character_)
+
+  if (!is.na(api_key) && nzchar(api_key)) {
+    queries$apikey <- api_key
+  }
+  
   pl <- httr::GET(httr::modify_url(base_url, query = queries))
   .response_OK(pl)
 

--- a/R/marine_forecast.R
+++ b/R/marine_forecast.R
@@ -81,7 +81,7 @@ marine_forecast <- function(
     stop("start and end dates must be in ISO-1806 format")
   }
 
-  base_url <- "https://marine-api.open-meteo.com/v1/marine"
+  base_url <- .lookup_open_meteo_url(fxn_name = "marine_forecast")
 
   .query_openmeteo(
     location,

--- a/R/river_discharge.R
+++ b/R/river_discharge.R
@@ -67,7 +67,7 @@ river_discharge <- function(
     stop("start and end dates must be in ISO-1806 format")
   }
 
-  base_url <- "https://flood-api.open-meteo.com/v1/flood"
+  base_url <- .lookup_open_meteo_url(fxn_name = "river_discharge")
 
   .query_openmeteo(
     location,

--- a/R/utils.R
+++ b/R/utils.R
@@ -46,6 +46,12 @@ utils::globalVariables(c("time", "datetime"))
   ## handle downscaling switch for climate forecast
   if(!is.null(downscaling))queries[["disable_bias_correction"]] <- paste(!downscaling, collapse = ",")
 
+  api_key <- Sys.getenv("OPENMETEO_API_KEY", unset = NA_character_)
+
+  if (!is.na(api_key) && nzchar(api_key)) {
+    queries$apikey <- api_key
+  }
+
   # request (decode necessary as API treats ',' differently to '%2C')
   pl <- httr::GET(utils::URLdecode(httr::modify_url(base_url, query = queries)))
   .response_OK(pl)
@@ -209,3 +215,67 @@ utils::globalVariables(c("time", "datetime"))
   })
   dplyr::bind_rows(rows)
 }
+
+
+# lookup API endpoint for a function, switching to customer URL if API key is set
+.lookup_open_meteo_url <- local({
+  urls <- list(
+    air_quality = c(
+      noncommercial = "https://air-quality-api.open-meteo.com/v1/air-quality",
+      commercial = "https://customer-air-quality-api.open-meteo.com/v1/air-quality"
+    ),
+    climate_forecast = c(
+      noncommercial = "https://climate-api.open-meteo.com/v1/climate",
+      commercial = "https://customer-climate-api.open-meteo.com/v1/climate"
+    ),
+    ensemble_models = c(
+      noncommercial = "https://ensemble-api.open-meteo.com/v1/ensemble",
+      commercial = "https://customer-ensemble-api.open-meteo.com/v1/ensemble"
+    ),
+    geocode = c(
+      noncommercial = "https://geocoding-api.open-meteo.com/v1/search",
+      commercial = "https://customer-geocoding-api.open-meteo.com/v1/search"
+    ),
+    marine_forecast = c(
+      noncommercial = "https://marine-api.open-meteo.com/v1/marine",
+      commercial = "https://customer-marine-api.open-meteo.com/v1/marine"
+    ),
+    river_discharge = c(
+      noncommercial = "https://flood-api.open-meteo.com/v1/flood",
+      commercial = "https://customer-flood-api.open-meteo.com/v1/flood"
+    ),
+    weather_forecast = c(
+      noncommercial = "https://api.open-meteo.com/v1/forecast",
+      commercial = "https://customer-api.open-meteo.com/v1/forecast"
+    ),
+    weather_history = c(
+      noncommercial = "https://archive-api.open-meteo.com/v1/archive",
+      commercial = "https://customer-archive-api.open-meteo.com/v1/archive"
+    ),
+    weather_now = c(
+      noncommercial = "https://api.open-meteo.com/v1/forecast",
+      commercial = "https://customer-api.open-meteo.com/v1/forecast"
+    )
+  )
+
+  function(fxn_name) {
+    if (!is.character(fxn_name) || length(fxn_name) != 1L || is.na(fxn_name)) {
+      stop("'fxn_name' must be a single non-missing character value.", call. = FALSE)
+    }
+
+    if (!fxn_name %in% names(urls)) {
+      stop(
+        sprintf("'fxn_name' must be one of: %s", paste(names(urls), collapse = ", ")),
+        call. = FALSE
+      )
+    }
+
+    url_type <- if (isTRUE(nzchar(Sys.getenv("OPENMETEO_API_KEY")))) {
+      "commercial"
+    } else {
+      "noncommercial"
+    }
+
+    unname(urls[[fxn_name]][[url_type]])
+  }
+})

--- a/R/weather_forecast.R
+++ b/R/weather_forecast.R
@@ -98,7 +98,7 @@ weather_forecast <- function(
     stop("start and end dates must be in ISO-1806 format")
   }
 
-  base_url <- "https://api.open-meteo.com/v1/forecast"
+  base_url <- .lookup_open_meteo_url(fxn_name = "weather_forecast")
 
   .query_openmeteo(
     location,

--- a/R/weather_history.R
+++ b/R/weather_history.R
@@ -78,7 +78,7 @@ weather_history <- function(
     stop("start and end dates must be in ISO-1806 format")
   }
 
-  base_url <- "https://archive-api.open-meteo.com/v1/archive"
+  base_url <- .lookup_open_meteo_url(fxn_name = "weather_history")
 
   .query_openmeteo(
     location,

--- a/R/weather_now.R
+++ b/R/weather_now.R
@@ -44,6 +44,12 @@ weather_now <- function(
   # add units as supplied
   queries <- c(queries, response_units)
 
+  api_key <- Sys.getenv("OPENMETEO_API_KEY", unset = NA_character_)
+
+  if (!is.na(api_key) && nzchar(api_key)) {
+    queries$apikey <- api_key
+  }
+
   # request (decode necessary as API treats ',' differently to '%2C')
   pl <- httr::GET(utils::URLdecode(httr::modify_url(base_url, query = queries)))
   .response_OK(pl)

--- a/R/weather_now.R
+++ b/R/weather_now.R
@@ -31,7 +31,7 @@ weather_now <- function(
     response_units = NULL,
     timezone = "auto") {
   coordinates <- .coords_generic(location)
-  base_url <- "https://api.open-meteo.com/v1/forecast"
+  base_url <- .lookup_open_meteo_url(fxn_name = "weather_now")
 
   # base queries
   queries <- list(

--- a/README.md
+++ b/README.md
@@ -1,54 +1,44 @@
----
-editor_options: 
-  markdown: 
-    wrap: 72
----
-
 # openmeteo
-
-*An Open Meteo SDK for R*
+_An Open Meteo SDK for R_
 
 <!-- badges: start -->
-
 [![R-CMD-check](https://github.com/tpisel/openmeteo/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/tpisel/openmeteo/actions/workflows/R-CMD-check.yaml)
-
 <!-- badges: end -->
 
-`openmeteo` provides functions for accessing the [Open-Meteo weather
-API](https://open-meteo.com/), enabling the desired weather data or
-forecasts to be retrieved in a tidy data format. An API key is *not*
-required to access the Open-Meteo API.
+`openmeteo` provides functions for accessing the [Open-Meteo
+weather API](https://open-meteo.com/), enabling the desired weather data or forecasts to be retrieved
+in a tidy data format. An API key is _not_ required to access the
+Open-Meteo API.
 
-Install and load with:
-`install.packages("openmeteo") library(openmeteo)`\
-Getting current weather for a location is as easy as:
-`weather_now('tokyo')`\
+Install and load with: `install.packages("openmeteo") library(openmeteo)`  
+Getting current weather for a location is as easy as: `weather_now('tokyo')`  
 Explore the documentation with `?openmeteo`
 
-Open-Meteo provides several API endpoints through the following
-functions:
+Open-Meteo provides several API endpoints through the following functions:
 
-**Core Weather APIs** - `weather_forecast()` - retrieve weather
-forecasts for a location - `weather_history()` - retrieve historical
-weather observations for a location - `weather_now()` - simple function
-to return current weather for a location - `weather_variables()` -
-retrieve a shortlist of valid forecast or historical weather variables
-provided
+**Core Weather APIs**
+ - `weather_forecast()` - retrieve weather forecasts for a location
+ - `weather_history()` - retrieve historical weather observations for a
+ location
+ - `weather_now()` - simple function to return current weather for a
+ location
+ - `weather_variables()` - retrieve a shortlist of valid forecast or
+ historical weather variables provided
 
-**Other APIs** - `geocode()` - return the co-ordinates and other data
-for a location name - `ensemble_models()` - return ensemble model
-forecasts for a location - `climate_forecast()` - return long-range
-climate modelling for a location - `river_discharge()` - return flow
-volumes for the nearest river - `marine_forecast()` - return ocean
-conditions data for a location - `air_quality()` - return air quality
-data for a location
+**Other APIs**
+ - `geocode()` - return the co-ordinates and other data for a location name
+ - `ensemble_models()` - return ensemble model forecasts for a location
+ - `climate_forecast()` - return long-range climate modelling for a location
+ - `river_discharge()` - return flow volumes for the nearest river
+ - `marine_forecast()` - return ocean conditions data for a location
+ - `air_quality()` - return air quality data for a location
 
-Please review the API documentation at
-[Open-Meteo.com](https://open-meteo.com/) for details regarding the data
-available, its types, units, and other caveats and considerations.
 
-Please feel free to raise any issues / pull requests if your use case is
-not supported.
+Please review the API documentation at [Open-Meteo.com](https://open-meteo.com/) for
+details regarding the data available, its types, units, and other caveats
+and considerations.
+
+Please feel free to raise any issues / pull requests if your use case is not supported.
 
 ## Authentication (Optional)
 

--- a/README.md
+++ b/README.md
@@ -1,45 +1,77 @@
+---
+editor_options: 
+  markdown: 
+    wrap: 72
+---
+
 # openmeteo
-_An Open Meteo SDK for R_
+
+*An Open Meteo SDK for R*
 
 <!-- badges: start -->
+
 [![R-CMD-check](https://github.com/tpisel/openmeteo/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/tpisel/openmeteo/actions/workflows/R-CMD-check.yaml)
+
 <!-- badges: end -->
 
-`openmeteo` provides functions for accessing the [Open-Meteo
-weather API](https://open-meteo.com/), enabling the desired weather data or forecasts to be retrieved
-in a tidy data format. An API key is _not_ required to access the
-Open-Meteo API.
+`openmeteo` provides functions for accessing the [Open-Meteo weather
+API](https://open-meteo.com/), enabling the desired weather data or
+forecasts to be retrieved in a tidy data format. An API key is *not*
+required to access the Open-Meteo API.
 
-Install and load with: `install.packages("openmeteo") library(openmeteo)`  
-Getting current weather for a location is as easy as: `weather_now('tokyo')`  
+Install and load with:
+`install.packages("openmeteo") library(openmeteo)`\
+Getting current weather for a location is as easy as:
+`weather_now('tokyo')`\
 Explore the documentation with `?openmeteo`
 
-Open-Meteo provides several API endpoints through the following functions:
+Open-Meteo provides several API endpoints through the following
+functions:
 
-**Core Weather APIs**
- - `weather_forecast()` - retrieve weather forecasts for a location
- - `weather_history()` - retrieve historical weather observations for a
- location
- - `weather_now()` - simple function to return current weather for a
- location
- - `weather_variables()` - retrieve a shortlist of valid forecast or
- historical weather variables provided
+**Core Weather APIs** - `weather_forecast()` - retrieve weather
+forecasts for a location - `weather_history()` - retrieve historical
+weather observations for a location - `weather_now()` - simple function
+to return current weather for a location - `weather_variables()` -
+retrieve a shortlist of valid forecast or historical weather variables
+provided
 
-**Other APIs**
- - `geocode()` - return the co-ordinates and other data for a location name
- - `ensemble_models()` - return ensemble model forecasts for a location
- - `climate_forecast()` - return long-range climate modelling for a location
- - `river_discharge()` - return flow volumes for the nearest river
- - `marine_forecast()` - return ocean conditions data for a location
- - `air_quality()` - return air quality data for a location
+**Other APIs** - `geocode()` - return the co-ordinates and other data
+for a location name - `ensemble_models()` - return ensemble model
+forecasts for a location - `climate_forecast()` - return long-range
+climate modelling for a location - `river_discharge()` - return flow
+volumes for the nearest river - `marine_forecast()` - return ocean
+conditions data for a location - `air_quality()` - return air quality
+data for a location
 
+Please review the API documentation at
+[Open-Meteo.com](https://open-meteo.com/) for details regarding the data
+available, its types, units, and other caveats and considerations.
 
-Please review the API documentation at [Open-Meteo.com](https://open-meteo.com/) for
-details regarding the data available, its types, units, and other caveats
-and considerations.
+Please feel free to raise any issues / pull requests if your use case is
+not supported.
 
-Please feel free to raise any issues / pull requests if your use case is not supported.
+## Authentication (Optional)
 
+Most Open-Meteo APIs can be accessed without an API key.
 
+Users with a paid Open-Meteo subscription can authenticate by setting
+the `OPENMETEO_API_KEY` environment variable:
 
+``` r
+Sys.setenv(OPENMETEO_API_KEY = "your-api-key")
+```
 
+For persistent configuration, add the key to your `.Renviron` file:
+
+``` text
+OPENMETEO_API_KEY=your-api-key
+```
+
+When set, `openmeteo` will automatically include the API key in requests
+and switch to Open-Meteo commercial endpoints.
+
+Please review Open-Meteo's Terms of Service and License for details
+regarding commercial and non-commercial use:
+
+-   <https://open-meteo.com/en/terms>
+-   <https://open-meteo.com/en/licence>


### PR DESCRIPTION
## Summary

This PR adds support for Open-Meteo commercial customer endpoints for users with a paid subscription.

### Changes

* Added support for the `OPENMETEO_API_KEY` environment variable.
* Automatically routes requests to Open-Meteo commercial (`customer-*`) endpoints when an API key is configured.
* Preserves existing behavior by continuing to use public endpoints when no API key is provided.
* Added API key handling to shared query utilities and geocoding/current weather requests.
* Added a centralized `.lookup_open_meteo_url()` helper for endpoint selection.
* Updated package requirements to depend on R (>= 4.1.0).
* Added documentation and usage examples to the README.
* Added a NEWS entry describing the new functionality.

### Backward Compatibility

This change is fully backward compatible. Users who do not configure `OPENMETEO_API_KEY` will see no change in behavior and will continue to use the existing public Open-Meteo endpoints.

### Testing

* Verified functionality against the package examples and existing testthat code using a paid Open-Meteo API key.
* Ran `devtools::check()` with no errors, warnings, or notes.

### Design Notes

The goal was to add support for commercial endpoints with minimal impact on the existing API. Endpoint selection is handled internally based on the presence of `OPENMETEO_API_KEY`, avoiding changes to function signatures or existing user workflows while maintaining backward compatibility.

If you would prefer a different design pattern for implementing this type of improvement or other changes to improve this, please let me know.

P.S.: i saw in another comment you made that you had a kiddo recently. Congrats! 🎉